### PR TITLE
Add BOM API

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -76,4 +76,4 @@ Ace web APIs.  The table below shows the web APIs supported by each client:
 | Configuration API  |                         | ☑️                               | ☑️                         | ☑️                                 |
 | Solution Space API |                         |                                  | ☑️                         |                                    |
 | Analyze API        |                         | ☑️                               | ☑️                         |                                    |
-
+| BOM API            |                         | ☑️                               | ☑️                         |                                    |


### PR DESCRIPTION
Add the BOM API to client library table. 
Should not be merged until after the 6.2 release.